### PR TITLE
Allow multiple TEST_CASE test suites in a single Objective-C++ file with Xcode back end

### DIFF
--- a/include/Cuti.h
+++ b/include/Cuti.h
@@ -476,9 +476,9 @@ struct className; /*forward declaration*/ \
     ##className : XCTestCase {\
 }        \
     \
++ (className*)instanceControl:(int)inCmd; \
+- (className*)getInstance; \
 @end                                      \
-    \
-static className *kInstance = nullptr;    \
     \
 @implementation C                         \
     ##className \
@@ -505,7 +505,7 @@ struct className : public cuti::CutiBaseTestCase
     \
 -(void)test_##testMethod           \
     {                              \
-        kInstance->testMethod();   \
+        [self getInstance]->testMethod();   \
     \
 }
 #else
@@ -517,7 +517,7 @@ struct className : public cuti::CutiBaseTestCase
     \
 -(void)testMethod                  \
     {                              \
-        kInstance->testMethod();   \
+        [self getInstance]->testMethod();   \
     \
 }
 #endif
@@ -530,16 +530,31 @@ struct className : public cuti::CutiBaseTestCase
     ;                                                 \
     \
 _Pragma("clang diagnostic pop") \
++ (className*)instanceControl:(int)inCmd              \
+{                                                     \
+    static className* kInstance = nullptr;            \
+    switch ( inCmd )                                  \
+    {                                                 \
+        case 10: kInstance = new className(); break;  \
+        case 20: delete kInstance; break;             \
+        default: break;                               \
+    }                                                 \
+    return kInstance;                                 \
+}                                                     \
+- (className*)getInstance                             \
+{                                                     \
+    return [C ## className instanceControl:0];        \
+}                                                     \
 + (void)setUp                                         \
     {                                                 \
         [super setUp];                                \
-        kInstance = new className();                  \
+       [self instanceControl:10];                     \
     \
 }                                              \
     \
 +(void)tearDown                                       \
     {                                                 \
-        delete kInstance;                             \
+        [self instanceControl:20];                    \
         [super tearDown];                             \
     \
 }                                              \
@@ -548,14 +563,14 @@ _Pragma("clang diagnostic pop") \
     {                                                 \
         [super setUp];                                \
         self.continueAfterFailure = NO;               \
-        kInstance->self = self;                       \
-        kInstance->setUp();                           \
+        [self getInstance]->self = self;              \
+        [self getInstance]->setUp();                  \
     \
 }                                              \
     \
 -(void)tearDown                                       \
     {                                                 \
-        kInstance->tearDown();                        \
+        [self getInstance]->tearDown();               \
         [super tearDown];                             \
     \
 }


### PR DESCRIPTION
For the Xcode back end, this change replaces the kInstance file static variable with a static variable inside of a class method. This allows multiple TEST_CASE test suites to be defined in a single translation unit (e.g. from #including other files which may themselves have test suites).
I had needed this because I had set up my unit testing target in my Xcode project with a single .mm file that performed the appropriate platform-specific #defines and #include of Cuti.h before #including some cross-platform test sources.