### PR TITLE
Fix for compare when a single use function is used (#4)

### DIFF
--- a/include/Cuti.h
+++ b/include/Cuti.h
@@ -497,7 +497,11 @@ INTERNAL_CUTI_SPECIALIZED_TO_STRING(uint16_t);
         expression;                                               \
     } while (false)
 
-#define INTERNAL_CUTI_ASSERT_COMPARE(bound, operation, actual, msg, ...) IMPL_CUTI_ASSERT(bound operation actual, cuti::ToString(actual) + std::string(msg) + cuti::ToString(bound) + cuti::CutiGetMessage(__VA_ARGS__))
+#define INTERNAL_CUTI_ASSERT_COMPARE(bound, operation, actual, msg, ...) \
+{ \
+auto const &boundResult = bound; \
+IMPL_CUTI_ASSERT(boundResult operation actual, cuti::ToString(actual) + std::string(msg) + cuti::ToString(boundResult) + cuti::CutiGetMessage(__VA_ARGS__)); \
+}
 
 /*************************************************
 * Visual studio CUTI assert macro implementations*


### PR DESCRIPTION
This is a proposed fix for item #4.

The macro INTERNAL_CUTI_ASSERT_COMPARE uses the macro input 'bound' for creation of an information string and is passed to another macro IMPL_CUTI_ASSERT for the actual assertion.

If the caller used a 'one-time' function, e.g. 'Initialize' directly in a comparison macro then this would not execute correctly. The 'Initialize' function would be called twice, which situation depending might produce the wrong outcome or an unwanted exception.

Changed macro to execute the bound and store its result (or create a reference for P.O.D).
This return value is then asserted for bounds and used to construct an information string.