### PR TITLE
Fix transitive inclusion of this CMakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #The MIT License (MIT)
 #
-#Copyright (c) 2018 k-brac
+#Copyright (c) 2020 k-brac
 #
 #Permission is hereby granted, free of charge, to any person obtaining a copy
 #of this software and associated documentation files (the "Software"), to deal
@@ -46,8 +46,13 @@ option(CUTI_USE_LONG_MACRO_NAME "Select wether you want to use long macro names"
 set_property(CACHE CUTI_FRONT_END PROPERTY STRINGS "CUTI" "CPPUNIT")
 set_property(CACHE CUTI_BACK_END PROPERTY STRINGS "CUTI" "CPPUNIT")
 
-string(COMPARE EQUAL "${CUTI_FRONT_END}" "CUTI" USE_CUTI_FRONT_END)
-string(COMPARE EQUAL "${CUTI_BACK_END}" "CUTI" USE_CUTI_BACK_END)
+string(COMPARE EQUAL "${CUTI_FRONT_END}" "CUTI" USE_CUTI_FRONT_END_CMP)
+string(COMPARE EQUAL "${CUTI_BACK_END}" "CUTI" USE_CUTI_BACK_END_CMP)
+
+set(USE_CUTI_FRONT_END ${USE_CUTI_FRONT_END_CMP} CACHE BOOL "Internal variable")
+set(USE_CUTI_BACK_END ${USE_CUTI_BACK_END_CMP} CACHE BOOL "Internal variable")
+
+mark_as_advanced(USE_CUTI_FRONT_END USE_CUTI_BACK_END)
 
 if(TARGET cuti)
 	return()
@@ -136,7 +141,7 @@ endif()
 
 if(WIN32)
 	target_compile_definitions(cuti INTERFACE
-		$<IF:${USE_CUTI_BACK_END},
+		$<IF:$<BOOL:${USE_CUTI_BACK_END}>,
 			CUTI_USES_MSVC_UNIT_BACKEND,
 			"CPPUNIT_PLUGIN_EXPORT=__attribute__((visibility(\"default\")))"
 			CUTI_USES_CPPUNIT_BACKEND
@@ -145,7 +150,7 @@ if(WIN32)
 	)
 elseif(${APPLE})
 	target_compile_definitions(cuti INTERFACE
-		$<IF:${USE_CUTI_BACK_END},
+		$<IF:$<BOOL:${USE_CUTI_BACK_END}>,
 			CUTI_USES_XCTEST_BACKEND,
 			"CPPUNIT_PLUGIN_EXPORT=__attribute__((visibility(\"default\")))"
 			CUTI_USES_CPPUNIT_BACKEND
@@ -172,12 +177,12 @@ else()
 endif()
 
 target_compile_definitions(cuti INTERFACE
-	$<IF:${USE_CUTI_BACK_END},
-		$<IF:${USE_CUTI_FRONT_END},
+	$<IF:$<BOOL:${USE_CUTI_BACK_END}>,
+		$<IF:$<BOOL:${USE_CUTI_FRONT_END}>,
 			CUTI_FREE_STANDING,
 			CUTI_CPPUNIT_COMPATABILITY
 		>,
-		$<IF:${USE_CUTI_FRONT_END},
+		$<IF:$<BOOL:${USE_CUTI_FRONT_END}>,
 			CUTI_UNKNOWN,
 			CUTI_NO_INTEGRATION
 		>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,10 +23,34 @@ jobs:
       packageApp: false
       publishJUnitResults: true
       scheme: testCuti
+      sdk: macosx11.0
+  - task: Xcode@5
+    inputs:
+      actions: 'test'
+      configuration: $(configuration)
+      packageApp: false
+      publishJUnitResults: true
+      scheme: testCppunit
+      sdk: macosx11.0
+- job: Xcode_11
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - bash: cmake -G "Xcode" ./test/testDynamicLib
+  - bash: cmake -G "Xcode" ./test/testDynamicLib
+  - task: Xcode@5
+    inputs:
+      actions: 'test'
+      xcodeVersion: '11'
+      configuration: $(configuration)
+      packageApp: false
+      publishJUnitResults: true
+      scheme: testCuti
       sdk: macosx10.15
   - task: Xcode@5
     inputs:
       actions: 'test'
+      xcodeVersion: '11'
       configuration: $(configuration)
       packageApp: false
       publishJUnitResults: true
@@ -56,30 +80,6 @@ jobs:
       publishJUnitResults: true
       scheme: testCppunit
       sdk: macosx10.14
-- job: Xcode_9
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-  - bash: cmake -G "Xcode" ./test/testDynamicLib
-  - bash: cmake -G "Xcode" ./test/testDynamicLib
-  - task: Xcode@5
-    inputs:
-      actions: 'test'
-      xcodeVersion: '9'
-      configuration: $(configuration)
-      packageApp: false
-      publishJUnitResults: true
-      scheme: testCuti
-      sdk: macosx10.13
-  - task: Xcode@5
-    inputs:
-      actions: 'test'
-      xcodeVersion: '9'
-      configuration: $(configuration)
-      packageApp: false
-      publishJUnitResults: true
-      scheme: testCppunit
-      sdk: macosx10.13
 - job: VS_latest
   pool:
     vmImage: 'windows-latest'
@@ -114,21 +114,4 @@ jobs:
       testRunTitle: 'CUTI'
       platform: 'vs2017-win2016'
       configuration: $(configuration)
-# - job: VS_2015
-#   pool:
-#     vmImage: 'vs2015-win2012r2'
-#   steps:
-#   - script: cmake.exe --version
-#   - script: cmake.exe -G "Visual Studio 14 2015 Win64" ./test/testDynamicLib
-#   - script: cmake.exe --build . --config $(configuration)
-#   - task: VSTest@2
-#     inputs:
-#       testSelector: 'testAssemblies'
-#       testAssemblyVer2: |
-#         **\*test*.dll
-#         !**\*TestAdapter.dll
-#         !**\obj\**
-#       searchFolder: '$(System.DefaultWorkingDirectory)'
-#       testRunTitle: 'CUTI'
-#       platform: 'vs2015-win2012r2'
-#       configuration: $(configuration)
+


### PR DESCRIPTION
It seems that CMake propagates variables between CMakelists.txt differently on windows and mac.
to fix this we save some of the needed variables to the cache